### PR TITLE
Fix balance notifications during HTLC routing

### DIFF
--- a/cmd/telegram-monitor/main.go
+++ b/cmd/telegram-monitor/main.go
@@ -75,6 +75,7 @@ func main() {
 	checkForwardingActivity(currentState)
 	checkInvoiceChanges(currentState, prevState)
 	checkBalanceChanges(currentState, prevState)
+	checkRoutingActivity(currentState, prevState)
 
 	// Save current state
 	if err := saveState(currentState); err != nil {


### PR DESCRIPTION
Filter balance change notifications to exclude HTLC routing activity

Balance changes during HTLC routing were creating false notifications that looked like actual payments but were just temporary routing state changes. This change filters balance notifications to only report actual sent/received payments while adding separate routing activity messages.

Changes:
- Modified checkBalanceChanges() to filter Lightning balance changes through payment detection logic
- Added isBalanceChangeFromPayment() to distinguish real payments from routing activity
- Added checkRoutingActivity() to provide separate notifications for successful routing
- On-chain changes still reported immediately (always real payments)
- Routing activity requires 10x threshold to be considered actual payment