### PR TITLE
Strike balance checker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,11 @@ CHAT_ID=your_telegram_chat_id_here
 # ===== WEBHOOK DEPLOYER =====
 WEBHOOK_SECRET=your_github_webhook_secret_here
 
+# ===== STRIKE BALANCE TRACKING =====
+# Get API key from Strike: Settings → Developer → API Keys
+# Requires 'partner.balances.read' scope
+STRIKE_API_KEY=your_strike_api_key_here
+
 # ===== OPTIONAL SETTINGS =====
 # Uncomment and modify these if you need custom settings
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-.PHONY: build clean all channel-manager telegram-monitor dashboard-api forwarding-collector dashboard deploy install-services test test-verbose test-coverage test-unit test-integration test-api test-forwarding test-db test-utils test-race test-clean
+.PHONY: build clean all channel-manager telegram-monitor dashboard-api forwarding-collector strike-balance-collector dashboard deploy install-services test test-verbose test-coverage test-unit test-integration test-api test-forwarding test-db test-utils test-race test-clean
 
 # Default target - build all tools
 all: build
 
 # Build all tools
-build: channel-manager telegram-monitor portfolio-api forwarding-collector webhook-deployer
+build: channel-manager telegram-monitor portfolio-api forwarding-collector strike-balance-collector webhook-deployer
 
 # Build channel-manager
 channel-manager:
@@ -30,6 +30,12 @@ forwarding-collector:
 	@echo "Building forwarding-collector..."
 	@mkdir -p bin
 	go build -o bin/forwarding-collector ./services/lightning/forwarding-collector
+
+# Build strike-balance-collector
+strike-balance-collector:
+	@echo "Building strike-balance-collector..."
+	@mkdir -p bin
+	go build -o bin/strike-balance-collector ./services/strike/balance-collector
 
 # Build webhook-deployer
 webhook-deployer:
@@ -163,6 +169,7 @@ help:
 	@echo "  telegram-monitor    - Build only telegram-monitor"
 	@echo "  portfolio-api       - Build only portfolio-api"
 	@echo "  forwarding-collector - Build only forwarding-collector"
+	@echo "  strike-balance-collector - Build only strike-balance-collector"
 	@echo "  portfolio           - Build complete portfolio system"
 	@echo "  install-services    - Install/update systemd service files"
 	@echo "  install-services-auto - Install systemd services automatically (recommended)"

--- a/deployment/systemd/strike-balance-collector.service.example
+++ b/deployment/systemd/strike-balance-collector.service.example
@@ -1,0 +1,37 @@
+[Unit]
+Description=Strike Balance Collector Service
+Documentation=https://github.com/brewgator/lightning-node-tools
+After=network.target
+
+[Service]
+Type=simple
+User=bitcoin
+Group=bitcoin
+WorkingDirectory=/opt/lightning-node-tools
+ExecStart=/opt/lightning-node-tools/bin/strike-balance-collector \
+    --db=/opt/lightning-node-tools/data/portfolio.db \
+    --interval=15m
+
+# Environment variables
+# Option 1: Set directly in this file
+Environment="STRIKE_API_KEY=your_strike_api_key_here"
+# Option 2: Or configure in .env file at /opt/lightning-node-tools/.env
+
+# Restart configuration
+Restart=on-failure
+RestartSec=30s
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=strike-balance-collector
+
+# Security hardening
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/opt/lightning-node-tools/data
+
+[Install]
+WantedBy=multi-user.target

--- a/deployment/systemd/strike-balance-collector.service.example
+++ b/deployment/systemd/strike-balance-collector.service.example
@@ -5,17 +5,15 @@ After=network.target
 
 [Service]
 Type=simple
-User=bitcoin
-Group=bitcoin
-WorkingDirectory=/opt/lightning-node-tools
-ExecStart=/opt/lightning-node-tools/bin/strike-balance-collector \
-    --db=/opt/lightning-node-tools/data/portfolio.db \
+WorkingDirectory={{WORKING_DIRECTORY}}
+ExecStart={{WORKING_DIRECTORY}}/bin/strike-balance-collector \
+    --db={{WORKING_DIRECTORY}}/data/portfolio.db \
     --interval=15m
 
 # Environment variables
 # Option 1: Set directly in this file
 Environment="STRIKE_API_KEY=your_strike_api_key_here"
-# Option 2: Or configure in .env file at /opt/lightning-node-tools/.env
+# Option 2: Or configure in .env file at {{WORKING_DIRECTORY}}/.env
 
 # Restart configuration
 Restart=on-failure
@@ -30,8 +28,8 @@ SyslogIdentifier=strike-balance-collector
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
-ProtectHome=true
-ReadWritePaths=/opt/lightning-node-tools/data
+ProtectHome=read-only
+ReadWritePaths={{WORKING_DIRECTORY}}/data
 
 [Install]
 WantedBy=multi-user.target

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -866,6 +866,7 @@ func (db *Database) GetColdStorageEntriesWithWarnings() ([]map[string]interface{
 
 	return entries, rows.Err()
 }
+
 // InsertStrikeBalanceSnapshot stores a Strike balance snapshot
 func (db *Database) InsertStrikeBalanceSnapshot(snapshot *StrikeBalanceSnapshot) error {
 	tableName := db.getTableName("strike_balance_snapshots")

--- a/internal/db/types.go
+++ b/internal/db/types.go
@@ -96,3 +96,14 @@ type ColdStorageBalanceHistory struct {
 	IsVerified      bool      `json:"is_verified" db:"is_verified"`
 	Notes           string    `json:"notes" db:"notes"`
 }
+
+// StrikeBalanceSnapshot represents Strike account balance at a point in time
+type StrikeBalanceSnapshot struct {
+	ID        int64     `json:"id" db:"id"`
+	Timestamp time.Time `json:"timestamp" db:"timestamp"`
+	Currency  string    `json:"currency" db:"currency"`   // "BTC", "USD", etc.
+	Available int64     `json:"available" db:"available"` // Sats for BTC, cents for fiat
+	Total     int64     `json:"total" db:"total"`
+	Pending   int64     `json:"pending" db:"pending"`
+	Reserved  int64     `json:"reserved" db:"reserved"`
+}

--- a/internal/strike/client.go
+++ b/internal/strike/client.go
@@ -1,0 +1,154 @@
+package strike
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+const (
+	// DefaultBaseURL is the Strike API base URL
+	DefaultBaseURL = "https://api.strike.me/v1"
+)
+
+// Client is a Strike API client
+type Client struct {
+	apiKey  string
+	baseURL string
+	client  *http.Client
+}
+
+// BalanceResponse represents a single currency balance from Strike API
+type BalanceResponse struct {
+	Currency  string `json:"currency"`
+	Available string `json:"available"`
+	Total     string `json:"total"`
+	Pending   string `json:"pending"`
+	Reserved  string `json:"reserved"`
+	Outgoing  string `json:"outgoing"`
+	Current   string `json:"current"`
+}
+
+// BalanceDetail represents detailed balance information with parsed amounts
+type BalanceDetail struct {
+	Currency  string
+	Available int64 // In smallest unit (sats for BTC, cents for fiat)
+	Total     int64
+	Pending   int64
+	Reserved  int64
+	Timestamp time.Time
+}
+
+// NewClient creates a new Strike API client
+func NewClient(apiKey string) *Client {
+	return &Client{
+		apiKey:  apiKey,
+		baseURL: DefaultBaseURL,
+		client: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// GetAccountBalance fetches current account balance from Strike API
+func (c *Client) GetAccountBalance() ([]BalanceDetail, error) {
+	url := fmt.Sprintf("%s/balances", c.baseURL)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.apiKey))
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("strike API returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	var balances []BalanceResponse
+	if err := json.Unmarshal(body, &balances); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	// Convert to BalanceDetail with proper unit conversion
+	details := make([]BalanceDetail, 0, len(balances))
+	timestamp := time.Now()
+
+	for _, bal := range balances {
+		detail := BalanceDetail{
+			Currency:  bal.Currency,
+			Timestamp: timestamp,
+		}
+
+		// Convert string amounts to integers in smallest units
+		// For BTC: convert to satoshis
+		// For fiat: convert to cents
+		var err error
+		detail.Available, err = parseAmountToSmallestUnit(bal.Available, bal.Currency)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse available for %s: %w", bal.Currency, err)
+		}
+
+		detail.Total, err = parseAmountToSmallestUnit(bal.Total, bal.Currency)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse total for %s: %w", bal.Currency, err)
+		}
+
+		detail.Pending, err = parseAmountToSmallestUnit(bal.Pending, bal.Currency)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse pending for %s: %w", bal.Currency, err)
+		}
+
+		detail.Reserved, err = parseAmountToSmallestUnit(bal.Reserved, bal.Currency)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse reserved for %s: %w", bal.Currency, err)
+		}
+
+		details = append(details, detail)
+	}
+
+	return details, nil
+}
+
+// parseAmountToSmallestUnit converts Strike API string amounts to smallest units
+// For BTC: converts to satoshis (multiply by 100,000,000)
+// For fiat: converts to cents (multiply by 100)
+func parseAmountToSmallestUnit(amountStr, currency string) (int64, error) {
+	if amountStr == "" || amountStr == "0" {
+		return 0, nil
+	}
+
+	// Parse as float first
+	amount, err := strconv.ParseFloat(amountStr, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid amount format: %w", err)
+	}
+
+	// Convert to smallest unit based on currency
+	var multiplier float64
+	if currency == "BTC" {
+		multiplier = 100_000_000 // Convert BTC to satoshis
+	} else {
+		multiplier = 100 // Convert fiat to cents
+	}
+
+	// Round to nearest integer
+	smallestUnit := int64(amount*multiplier + 0.5)
+	return smallestUnit, nil
+}

--- a/services/strike/README.md
+++ b/services/strike/README.md
@@ -1,0 +1,238 @@
+# Strike Balance Tracking
+
+This service tracks your Strike account balance over time by periodically polling the Strike API and storing snapshots in the database.
+
+## Components
+
+### 1. Strike API Client (`internal/strike/client.go`)
+- Connects to Strike API
+- Fetches current account balances for all currencies
+- Converts amounts to smallest units (satoshis for BTC, cents for fiat)
+
+### 2. Balance Collector Service (`services/strike/balance-collector/`)
+- Runs periodically (default: every 15 minutes)
+- Fetches balance from Strike API
+- Stores snapshots in database
+- Supports mock mode for testing
+
+### 3. API Endpoints (`services/portfolio/api/main.go`)
+- `GET /api/strike/balance/current?currency=BTC` - Current balance
+- `GET /api/strike/balance/history?currency=BTC&days=30` - Historical balance (Chart.js format)
+
+## Setup
+
+### 1. Get Strike API Key
+
+1. Log in to your Strike account
+2. Go to Settings → Developer → API Keys
+3. Create a new API key with `partner.balances.read` scope
+4. Save the API key securely
+
+### 2. Configure API Key
+
+There are three ways to provide your Strike API key (in priority order):
+
+**Option 1: .env File (Recommended)**
+```bash
+# Edit your .env file in the project root (copy from .env.example if needed)
+echo "STRIKE_API_KEY=your_api_key_here" >> .env
+```
+
+The collector automatically loads from:
+- `/opt/lightning-node-tools/.env` (when installed as a service)
+- Project root `.env` (when running from bin/)
+- Current directory `.env` (for development)
+
+**Option 2: Environment Variable**
+```bash
+export STRIKE_API_KEY="your_api_key_here"
+./bin/strike-balance-collector --oneshot
+```
+
+**Option 3: Command-Line Flag**
+```bash
+./bin/strike-balance-collector --api-key="your_api_key_here" --oneshot
+```
+
+**Priority:** CLI flag > Environment variable > .env file
+
+### 3. Build the Service
+
+```bash
+make strike-balance-collector
+```
+
+### 4. Test in Mock Mode
+
+```bash
+./bin/strike-balance-collector --mock --oneshot
+```
+
+This will create mock data without calling the Strike API.
+
+### 5. Test with Real API
+
+```bash
+./bin/strike-balance-collector --oneshot --api-key="your_key"
+```
+
+This will fetch real data once and exit.
+
+### 6. Run as Service
+
+```bash
+# Run continuously (collects every 15 minutes by default)
+./bin/strike-balance-collector --api-key="your_key"
+
+# Custom interval
+./bin/strike-balance-collector --api-key="your_key" --interval=5m
+
+# Filter to only track BTC
+./bin/strike-balance-collector --api-key="your_key" --currency=BTC
+```
+
+## Systemd Service Installation
+
+1. Copy the example service file:
+```bash
+sudo cp deployment/systemd/strike-balance-collector.service.example \
+        /etc/systemd/system/strike-balance-collector.service
+```
+
+2. Edit the service file and add your API key:
+```bash
+sudo nano /etc/systemd/system/strike-balance-collector.service
+# Replace: Environment="STRIKE_API_KEY=your_strike_api_key_here"
+```
+
+3. Enable and start the service:
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable strike-balance-collector
+sudo systemctl start strike-balance-collector
+```
+
+4. Check status:
+```bash
+sudo systemctl status strike-balance-collector
+sudo journalctl -u strike-balance-collector -f
+```
+
+## API Usage
+
+### Get Current Balance
+
+```bash
+curl http://localhost:8090/api/strike/balance/current?currency=BTC | jq
+```
+
+Response:
+```json
+{
+  "success": true,
+  "data": {
+    "id": 123,
+    "timestamp": "2026-01-14T10:30:00Z",
+    "currency": "BTC",
+    "available": 5000000,
+    "total": 5100000,
+    "pending": 50000,
+    "reserved": 50000
+  }
+}
+```
+
+### Get Balance History
+
+```bash
+curl "http://localhost:8090/api/strike/balance/history?currency=BTC&days=7" | jq
+```
+
+Response (Chart.js format):
+```json
+{
+  "success": true,
+  "data": {
+    "labels": ["2026-01-07 10:00", "2026-01-07 10:15", ...],
+    "datasets": [
+      {
+        "label": "Available Balance (BTC)",
+        "data": [5000000, 5050000, ...],
+        "borderColor": "rgba(255, 159, 64, 1)",
+        ...
+      },
+      {
+        "label": "Total Balance (BTC)",
+        "data": [5100000, 5150000, ...],
+        "borderColor": "rgba(54, 162, 235, 1)",
+        ...
+      }
+    ],
+    "metadata": {
+      "currency": "BTC",
+      "days_requested": 7,
+      "days_with_data": 48
+    }
+  }
+}
+```
+
+## Database Schema
+
+```sql
+CREATE TABLE strike_balance_snapshots (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp DATETIME NOT NULL,
+    currency TEXT NOT NULL,
+    available INTEGER NOT NULL,  -- Satoshis for BTC, cents for fiat
+    total INTEGER NOT NULL,
+    pending INTEGER NOT NULL,
+    reserved INTEGER NOT NULL
+);
+```
+
+## Command-Line Flags
+
+- `--db` - Database path (default: `data/portfolio.db`)
+- `--interval` - Collection interval (default: `15m`)
+- `--oneshot` - Run once and exit (for testing)
+- `--mock` - Use mock data (no API calls)
+- `--api-key` - Strike API key (or use `STRIKE_API_KEY` env var)
+- `--currency` - Only track specific currency (e.g., `BTC`)
+
+## Troubleshooting
+
+### Check if service is running
+```bash
+systemctl status strike-balance-collector
+```
+
+### View logs
+```bash
+journalctl -u strike-balance-collector -f
+```
+
+### Test API connection
+```bash
+./bin/strike-balance-collector --oneshot --api-key="your_key"
+```
+
+### Query database directly
+```bash
+sqlite3 data/portfolio.db "SELECT * FROM strike_balance_snapshots ORDER BY timestamp DESC LIMIT 5;"
+```
+
+## Security Notes
+
+- Store your Strike API key securely
+- Never commit the API key to version control
+- Use environment variables or systemd service configuration
+- The API key only needs `partner.balances.read` scope (read-only)
+- Consider using a dedicated API key for this service
+
+## Next Steps
+
+To display Strike balance on the dashboard:
+1. Add a new chart component in the frontend
+2. Fetch data from `/api/strike/balance/history?currency=BTC&days=30`
+3. Render using Chart.js (same format as other charts)

--- a/services/strike/balance-collector/main.go
+++ b/services/strike/balance-collector/main.go
@@ -1,0 +1,282 @@
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/brewgator/lightning-node-tools/internal/db"
+	"github.com/brewgator/lightning-node-tools/internal/strike"
+)
+
+type Config struct {
+	DatabasePath       string
+	CollectionInterval time.Duration
+	StrikeClient       *strike.Client
+	CurrencyFilter     string // Optional: only track specific currency (e.g., "BTC")
+}
+
+type BalanceCollector struct {
+	config   *Config
+	db       *db.Database
+	mockMode bool
+}
+
+// loadEnv loads environment variables from .env file
+func loadEnv(envPath string) error {
+	file, err := os.Open(envPath)
+	if err != nil {
+		// .env file is optional, so don't fail if it doesn't exist
+		return nil
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+
+		key := strings.TrimSpace(parts[0])
+		value := strings.Trim(strings.TrimSpace(parts[1]), "\"")
+
+		// Only set if not already set in environment
+		if os.Getenv(key) == "" {
+			os.Setenv(key, value)
+		}
+	}
+
+	return scanner.Err()
+}
+
+func main() {
+	// Try to load .env file from project root
+	// This allows reading STRIKE_API_KEY from .env
+	exePath, err := os.Executable()
+	if err == nil {
+		exeDir := filepath.Dir(exePath)
+		// If running from bin/, go up one level to project root
+		projectRoot := filepath.Dir(exeDir)
+		envPath := filepath.Join(projectRoot, ".env")
+		if err := loadEnv(envPath); err != nil {
+			log.Printf("Warning: Failed to load .env file: %v", err)
+		}
+	}
+
+	// Also try loading from current directory (useful for development)
+	if err := loadEnv(".env"); err != nil {
+		log.Printf("Warning: Failed to load .env from current directory: %v", err)
+	}
+
+	var (
+		dbPath   = flag.String("db", "data/portfolio.db", "Path to SQLite database")
+		interval = flag.Duration("interval", 15*time.Minute, "Collection interval")
+		oneshot  = flag.Bool("oneshot", false, "Run once and exit (for testing)")
+		mockMode = flag.Bool("mock", false, "Use mock data for testing without Strike API")
+		apiKey   = flag.String("api-key", "", "Strike API key (or set STRIKE_API_KEY env var or in .env file)")
+		currency = flag.String("currency", "", "Optional: only track specific currency (BTC, USD, etc.)")
+	)
+	flag.Parse()
+
+	// Priority order: CLI flag > Environment variable > .env file
+	// Get API key from environment if not provided via flag
+	if *apiKey == "" {
+		*apiKey = os.Getenv("STRIKE_API_KEY")
+	}
+
+	// In mock mode, we don't need an API key
+	if !*mockMode && *apiKey == "" {
+		log.Fatal("❌ Strike API key required! Use --api-key flag, STRIKE_API_KEY environment variable, or add to .env file")
+	}
+
+	// Ensure data directory exists
+	if err := os.MkdirAll(filepath.Dir(*dbPath), 0755); err != nil {
+		log.Fatalf("Failed to create data directory: %v", err)
+	}
+
+	// Initialize database with mock mode support
+	database, err := db.NewDatabaseWithMockMode(*dbPath, *mockMode)
+	if err != nil {
+		log.Fatalf("Failed to initialize database: %v", err)
+	}
+	defer database.Close()
+
+	if *mockMode {
+		fmt.Println("📊 Using mock database tables (data will not affect real data)")
+	}
+
+	// Initialize Strike client
+	var strikeClient *strike.Client
+	if *mockMode {
+		fmt.Println("⚠️  Running in mock mode - using test data")
+		strikeClient = nil
+	} else {
+		strikeClient = strike.NewClient(*apiKey)
+		fmt.Println("⚡ Connected to Strike API")
+	}
+
+	config := &Config{
+		DatabasePath:       *dbPath,
+		CollectionInterval: *interval,
+		StrikeClient:       strikeClient,
+		CurrencyFilter:     *currency,
+	}
+
+	collector := &BalanceCollector{
+		config:   config,
+		db:       database,
+		mockMode: *mockMode,
+	}
+
+	if *oneshot {
+		fmt.Println("Running Strike balance collection once...")
+		if err := collector.collectBalances(); err != nil {
+			log.Fatalf("Strike balance collection failed: %v", err)
+		}
+		fmt.Println("Strike balance collection completed successfully")
+		return
+	}
+
+	// Set up signal handling for graceful shutdown
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+
+	// Start collection loop
+	ticker := time.NewTicker(config.CollectionInterval)
+	defer ticker.Stop()
+
+	fmt.Printf("Starting Strike balance collection every %v...\n", config.CollectionInterval)
+
+	// Collect initial data
+	if err := collector.collectBalances(); err != nil {
+		log.Printf("Initial Strike balance collection failed: %v", err)
+	}
+
+	for {
+		select {
+		case <-ticker.C:
+			if err := collector.collectBalances(); err != nil {
+				log.Printf("Strike balance collection failed: %v", err)
+			}
+		case <-sigChan:
+			fmt.Println("Received shutdown signal, exiting...")
+			return
+		}
+	}
+}
+
+func (c *BalanceCollector) collectBalances() error {
+	currentTime := time.Now()
+	fmt.Printf("[%s] Collecting Strike balances...\n",
+		currentTime.Format("2006-01-02 15:04:05"))
+
+	if c.mockMode {
+		return c.collectMockBalances()
+	}
+
+	if c.config.StrikeClient == nil {
+		return fmt.Errorf("Strike client is nil")
+	}
+
+	// Get balances from Strike API
+	balances, err := c.config.StrikeClient.GetAccountBalance()
+	if err != nil {
+		return fmt.Errorf("failed to get Strike balances: %w", err)
+	}
+
+	if len(balances) == 0 {
+		fmt.Printf("⚠️  No balances returned from Strike API\n")
+		return nil
+	}
+
+	// Insert each currency balance into database
+	var insertedCount int
+	for _, balance := range balances {
+		// Apply currency filter if specified
+		if c.config.CurrencyFilter != "" && balance.Currency != c.config.CurrencyFilter {
+			continue
+		}
+
+		snapshot := &db.StrikeBalanceSnapshot{
+			Timestamp: balance.Timestamp,
+			Currency:  balance.Currency,
+			Available: balance.Available,
+			Total:     balance.Total,
+			Pending:   balance.Pending,
+			Reserved:  balance.Reserved,
+		}
+
+		if err := c.db.InsertStrikeBalanceSnapshot(snapshot); err != nil {
+			log.Printf("Warning: failed to insert Strike balance for %s: %v", balance.Currency, err)
+			continue
+		}
+
+		fmt.Printf("  💰 %s: Available=%d, Total=%d\n",
+			balance.Currency,
+			balance.Available,
+			balance.Total)
+		insertedCount++
+	}
+
+	fmt.Printf("✅ Inserted %d Strike balance snapshots\n", insertedCount)
+	return nil
+}
+
+func (c *BalanceCollector) collectMockBalances() error {
+	// Create mock Strike balance data for testing
+	now := time.Now()
+
+	mockBalances := []*db.StrikeBalanceSnapshot{
+		{
+			Timestamp: now,
+			Currency:  "BTC",
+			Available: 5000000,  // 0.05 BTC in sats
+			Total:     5100000,  // 0.051 BTC in sats
+			Pending:   50000,    // 0.0005 BTC in sats
+			Reserved:  50000,    // 0.0005 BTC in sats
+		},
+		{
+			Timestamp: now,
+			Currency:  "USD",
+			Available: 100000,  // $1000.00 in cents
+			Total:     110000,  // $1100.00 in cents
+			Pending:   5000,    // $50.00 in cents
+			Reserved:  5000,    // $50.00 in cents
+		},
+	}
+
+	var insertedCount int
+	for _, balance := range mockBalances {
+		// Apply currency filter if specified
+		if c.config.CurrencyFilter != "" && balance.Currency != c.config.CurrencyFilter {
+			continue
+		}
+
+		if err := c.db.InsertStrikeBalanceSnapshot(balance); err != nil {
+			log.Printf("Warning: failed to insert mock Strike balance for %s: %v", balance.Currency, err)
+			continue
+		}
+
+		fmt.Printf("  💰 %s: Available=%d, Total=%d (mock)\n",
+			balance.Currency,
+			balance.Available,
+			balance.Total)
+		insertedCount++
+	}
+
+	fmt.Printf("✅ Inserted %d mock Strike balance snapshots\n", insertedCount)
+	return nil
+}

--- a/services/strike/balance-collector/main.go
+++ b/services/strike/balance-collector/main.go
@@ -243,18 +243,18 @@ func (c *BalanceCollector) collectMockBalances() error {
 		{
 			Timestamp: now,
 			Currency:  "BTC",
-			Available: 5000000,  // 0.05 BTC in sats
-			Total:     5100000,  // 0.051 BTC in sats
-			Pending:   50000,    // 0.0005 BTC in sats
-			Reserved:  50000,    // 0.0005 BTC in sats
+			Available: 5000000, // 0.05 BTC in sats
+			Total:     5100000, // 0.051 BTC in sats
+			Pending:   50000,   // 0.0005 BTC in sats
+			Reserved:  50000,   // 0.0005 BTC in sats
 		},
 		{
 			Timestamp: now,
 			Currency:  "USD",
-			Available: 100000,  // $1000.00 in cents
-			Total:     110000,  // $1100.00 in cents
-			Pending:   5000,    // $50.00 in cents
-			Reserved:  5000,    // $50.00 in cents
+			Available: 100000, // $1000.00 in cents
+			Total:     110000, // $1100.00 in cents
+			Pending:   5000,   // $50.00 in cents
+			Reserved:  5000,   // $50.00 in cents
 		},
 	}
 

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -744,28 +744,51 @@
 
                 // Get Strike data (may not be available)
                 let strikeData = [];
-                let strikeBalanceByDate = {};
+                let strikeBalanceByTimestamp = {};
                 if (strikeResponse.ok) {
                     const strikeResult = await strikeResponse.json();
                     if (strikeResult.success && strikeResult.data && strikeResult.data.labels) {
-                        // Create a map of date -> strike balance
+                        // Create a map of timestamp string -> strike balance
                         strikeResult.data.labels.forEach((label, idx) => {
-                            const strikeDate = label.split(' ')[0]; // Get just the date part
-                            strikeBalanceByDate[strikeDate] = strikeResult.data.datasets[0].data[idx] || 0;
+                            // Parse the Strike timestamp and normalize to date string
+                            const strikeTimestamp = label; // Format: "2026-01-14 16:07"
+                            strikeBalanceByTimestamp[strikeTimestamp] = strikeResult.data.datasets[0].data[idx] || 0;
                         });
                     }
                 }
 
                 const ctx = document.getElementById('portfolioChart').getContext('2d');
 
-                // Prepare data
+                // Prepare data with raw timestamps for matching
+                const portfolioTimestamps = portfolioResult.data.map(item => item.timestamp);
                 const labels = portfolioResult.data.map(item => new Date(item.timestamp).toLocaleDateString());
                 const lightningData = portfolioResult.data.map(item => calculatePortfolioComponents(item).lightning);
                 const onchainData = portfolioResult.data.map(item => calculatePortfolioComponents(item).onchain);
 
-                // Match Strike data to portfolio dates
-                strikeData = labels.map(label => {
-                    return strikeBalanceByDate[label] || 0;
+                // Match Strike data to portfolio timestamps
+                // For each portfolio timestamp, find the closest Strike balance
+                strikeData = portfolioTimestamps.map(portfolioTs => {
+                    // Parse portfolio timestamp
+                    const portfolioDate = new Date(portfolioTs);
+                    const portfolioDateStr = portfolioDate.toISOString().split('T')[0]; // Get YYYY-MM-DD
+
+                    // Look for Strike data on this date
+                    for (const [strikeTs, balance] of Object.entries(strikeBalanceByTimestamp)) {
+                        const strikeDate = strikeTs.split(' ')[0]; // Get YYYY-MM-DD from "2026-01-14 16:07"
+                        if (strikeDate === portfolioDateStr) {
+                            return balance;
+                        }
+                    }
+
+                    // If no exact match, use most recent available Strike balance (forward fill)
+                    let latestBalance = 0;
+                    for (const [strikeTs, balance] of Object.entries(strikeBalanceByTimestamp)) {
+                        const strikeDate = new Date(strikeTs.replace(' ', 'T') + ':00Z');
+                        if (strikeDate <= portfolioDate) {
+                            latestBalance = balance;
+                        }
+                    }
+                    return latestBalance;
                 });
 
                 // Calculate total portfolio including Strike

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -304,15 +304,6 @@
                     🔗 On-chain Management
                 </button>
                 <button type="button"
-                        id="tab-offline"
-                        class="nav-tab"
-                        role="tab"
-                        aria-selected="false"
-                        aria-controls="offline"
-                        onclick="showSection('offline', event)">
-                    🧊 Cold Storage
-                </button>
-                <button type="button"
                         id="tab-analytics"
                         class="nav-tab"
                         role="tab"
@@ -350,8 +341,8 @@
                 </div>
 
                 <div class="card">
-                    <h2>🧊 Cold Storage</h2>
-                    <div id="cold-storage-details">
+                    <h2>⚡ Strike Balance</h2>
+                    <div id="strike-details">
                         <!-- Populated by JavaScript -->
                     </div>
                 </div>
@@ -405,6 +396,22 @@
                         <canvas id="forwardsChart"></canvas>
                     </div>
                 </div>
+
+                <div class="card">
+                    <h2>⚡ Strike Balance History</h2>
+                    <div class="date-range-selector strike-range">
+                        <span class="date-range-label">Time Range:</span>
+                        <button class="date-range-btn strike-range" data-days="7">7D</button>
+                        <button class="date-range-btn strike-range active" data-days="30">30D</button>
+                        <button class="date-range-btn strike-range" data-days="90">90D</button>
+                        <button class="date-range-btn strike-range" data-days="365">1Y</button>
+                        <button class="date-range-btn strike-range" data-days="all">ALL</button>
+                    </div>
+                    <div class="chart-container">
+                        <div class="chart-loading" id="strikeChartLoading">⏳ Loading chart data...</div>
+                        <canvas id="strikeChart"></canvas>
+                    </div>
+                </div>
             </div>
         </div>
 
@@ -416,17 +423,20 @@
         let portfolioChart = null;
         let feesChart = null;
         let forwardsChart = null;
+        let strikeChart = null;
 
         // Global variables for date ranges
         let currentPortfolioRange = 30;
         let currentFeesRange = 30;
         let currentForwardsRange = 30;
+        let currentStrikeRange = 30;
 
         // LocalStorage keys
         const STORAGE_KEYS = {
             PORTFOLIO_RANGE: 'portfolio_date_range',
             FEES_RANGE: 'fees_date_range',
-            FORWARDS_RANGE: 'forwards_date_range'
+            FORWARDS_RANGE: 'forwards_date_range',
+            STRIKE_RANGE: 'strike_date_range'
         };
 
         // Load date ranges from localStorage
@@ -434,10 +444,12 @@
             const portfolioVal = localStorage.getItem(STORAGE_KEYS.PORTFOLIO_RANGE);
             const feesVal = localStorage.getItem(STORAGE_KEYS.FEES_RANGE);
             const forwardsVal = localStorage.getItem(STORAGE_KEYS.FORWARDS_RANGE);
+            const strikeVal = localStorage.getItem(STORAGE_KEYS.STRIKE_RANGE);
 
             currentPortfolioRange = portfolioVal === 'all' ? 'all' : (parseInt(portfolioVal) || 30);
             currentFeesRange = feesVal === 'all' ? 'all' : (parseInt(feesVal) || 30);
             currentForwardsRange = forwardsVal === 'all' ? 'all' : (parseInt(forwardsVal) || 30);
+            currentStrikeRange = strikeVal === 'all' ? 'all' : (parseInt(strikeVal) || 30);
         }
 
         // Save date range to localStorage
@@ -454,6 +466,8 @@
                 selector = '.card .fees-range';
             } else if (chartType === 'forwards') {
                 selector = '.card .forwards-range';
+            } else if (chartType === 'strike') {
+                selector = '.card .strike-range';
             }
 
             // Remove active class from all buttons in the selector group
@@ -512,8 +526,7 @@
         function calculatePortfolioComponents(data) {
             return {
                 lightning: data.lightning_local, // Only local balance belongs to us
-                onchain: data.onchain_confirmed + data.onchain_unconfirmed + data.tracked_addresses,
-                cold: data.cold_storage
+                onchain: data.onchain_confirmed + data.onchain_unconfirmed + data.tracked_addresses
             };
         }
 
@@ -539,11 +552,9 @@
             const components = calculatePortfolioComponents(data);
             const lightningTotal = components.lightning;
             const onchainTotal = components.onchain;
-            const coldTotal = components.cold;
 
             const lightningPercent = total > 0 ? ((lightningTotal / total) * 100).toFixed(1) : 0;
             const onchainPercent = total > 0 ? ((onchainTotal / total) * 100).toFixed(1) : 0;
-            const coldPercent = total > 0 ? ((coldTotal / total) * 100).toFixed(1) : 0;
 
             container.innerHTML = `
                 <div class="balance-item">
@@ -557,14 +568,6 @@
                 <div class="balance-item">
                     <span class="balance-label">🔗 On-chain (${onchainPercent}%):</span>
                     <span class="balance-value">${formatSats(onchainTotal)}</span>
-                </div>
-                <div class="balance-item">
-                    <span class="balance-label">🧊 Cold Storage (${coldPercent}%):</span>
-                    <span class="balance-value">${formatSats(coldTotal)}</span>
-                </div>
-                <div class="balance-item">
-                    <span class="balance-label">💧 Liquid (No Cold):</span>
-                    <span class="balance-value">${formatSats(data.total_liquid)}</span>
                 </div>
                 <div class="balance-item">
                     <span class="balance-label">Last Updated:</span>
@@ -630,29 +633,54 @@
             `;
         }
 
-        function updateColdStorageDetails(data) {
-            const container = document.getElementById('cold-storage-details');
-            const coldTotal = data.cold_storage;
-            const portfolioPercent = data.total_portfolio > 0 ? ((coldTotal / data.total_portfolio) * 100).toFixed(1) : 0;
+        async function updateStrikeDetails() {
+            const container = document.getElementById('strike-details');
 
-            container.innerHTML = `
-                <div class="balance-item">
-                    <span class="balance-label">❄️ Total Cold Storage:</span>
-                    <span class="balance-value">${formatSats(coldTotal)}</span>
-                </div>
-                <div class="balance-item">
-                    <span class="balance-label">Portfolio %:</span>
-                    <span class="balance-value">${portfolioPercent}% of total</span>
-                </div>
-                <div class="balance-item">
-                    <span class="balance-label">Security Status:</span>
-                    <span class="balance-value" style="color: #238636;">🔒 Cold (Offline)</span>
-                </div>
-                <div class="balance-item">
-                    <span class="balance-label">Liquidity:</span>
-                    <span class="balance-value" style="color: #d29922;">⚠️ Manual verification required</span>
-                </div>
-            `;
+            try {
+                const response = await fetch('/api/strike/balance/current?currency=BTC');
+                const result = await response.json();
+
+                if (!result.success || !result.data) {
+                    container.innerHTML = `
+                        <div class="balance-item">
+                            <span class="balance-label">Status:</span>
+                            <span class="balance-value" style="color: #8b949e;">No Strike data available</span>
+                        </div>
+                    `;
+                    return;
+                }
+
+                const strike = result.data;
+                const availableBTC = (strike.available / 100000000).toFixed(8);
+                const totalBTC = (strike.total / 100000000).toFixed(8);
+
+                container.innerHTML = `
+                    <div class="balance-item">
+                        <span class="balance-label">💰 Available:</span>
+                        <span class="balance-value">${formatSats(strike.available)}</span>
+                    </div>
+                    <div class="balance-item">
+                        <span class="balance-label">📊 Total:</span>
+                        <span class="balance-value">${formatSats(strike.total)}</span>
+                    </div>
+                    <div class="balance-item">
+                        <span class="balance-label">⏳ Pending:</span>
+                        <span class="balance-value">${formatSats(strike.pending)}</span>
+                    </div>
+                    <div class="balance-item">
+                        <span class="balance-label">Last Updated:</span>
+                        <span class="balance-value">${formatTimestamp(strike.timestamp)}</span>
+                    </div>
+                `;
+            } catch (error) {
+                console.error('Failed to load Strike balance:', error);
+                container.innerHTML = `
+                    <div class="balance-item">
+                        <span class="balance-label">Status:</span>
+                        <span class="balance-value" style="color: #f85149;">Error loading data</span>
+                    </div>
+                `;
+            }
         }
 
         // Show/hide loading indicator
@@ -693,10 +721,8 @@
                 // Prepare data
                 const labels = result.data.map(item => new Date(item.timestamp).toLocaleDateString());
                 const portfolioData = result.data.map(item => item.total_portfolio);
-                const liquidData = result.data.map(item => item.total_liquid);
                 const lightningData = result.data.map(item => calculatePortfolioComponents(item).lightning);
                 const onchainData = result.data.map(item => calculatePortfolioComponents(item).onchain);
-                const coldData = result.data.map(item => calculatePortfolioComponents(item).cold);
 
                 // Destroy existing chart
                 if (portfolioChart) {
@@ -729,23 +755,6 @@
                             borderColor: '#FF6B35',
                             backgroundColor: '#FF6B3520',
                             borderWidth: 2,
-                            fill: false,
-                            tension: 0.3,
-                        }, {
-                            label: '🧊 Cold Storage',
-                            data: coldData,
-                            borderColor: '#87CEEB',
-                            backgroundColor: '#87CEEB20',
-                            borderWidth: 2,
-                            fill: false,
-                            tension: 0.3,
-                        }, {
-                            label: '💧 Liquid (No Cold)',
-                            data: liquidData,
-                            borderColor: darkTheme.successColor,
-                            backgroundColor: darkTheme.successColor + '20',
-                            borderWidth: 1,
-                            borderDash: [5, 5],
                             fill: false,
                             tension: 0.3,
                         }]
@@ -1057,6 +1066,118 @@
             }
         }
 
+        // Chart 4: Strike Balance History (Line Chart)
+        async function createStrikeChart() {
+            try {
+                showChartLoading('strikeChart');
+
+                const daysParam = currentStrikeRange === 'all' ? '?days=all' : `?days=${currentStrikeRange}`;
+                const response = await fetch(`/api/strike/balance/history?currency=BTC${daysParam.replace('?', '&')}`);
+                if (!response.ok) {
+                    throw new Error(`HTTP error ${response.status}: ${response.statusText}`);
+                }
+                const result = await response.json();
+
+                if (!result.success || !result.data) {
+                    hideChartLoading('strikeChart');
+                    console.error('No Strike balance data available:', result.error || 'Empty dataset');
+                    return;
+                }
+
+                const ctx = document.getElementById('strikeChart').getContext('2d');
+
+                // Prepare data from API response
+                const chartData = result.data;
+                const labels = chartData.labels || [];
+                const availableData = chartData.datasets?.[0]?.data || [];
+                const totalData = chartData.datasets?.[1]?.data || [];
+
+                // Destroy existing chart
+                if (strikeChart) {
+                    strikeChart.destroy();
+                }
+
+                strikeChart = new Chart(ctx, {
+                    type: 'line',
+                    data: {
+                        labels: labels,
+                        datasets: [{
+                            label: 'Available Balance (BTC)',
+                            data: availableData,
+                            borderColor: 'rgba(255, 159, 64, 1)',
+                            backgroundColor: 'rgba(255, 159, 64, 0.2)',
+                            borderWidth: 2,
+                            fill: true,
+                            tension: 0.3,
+                        }, {
+                            label: 'Total Balance (BTC)',
+                            data: totalData,
+                            borderColor: 'rgba(54, 162, 235, 1)',
+                            backgroundColor: 'rgba(54, 162, 235, 0.2)',
+                            borderWidth: 2,
+                            fill: false,
+                            borderDash: [5, 5],
+                            tension: 0.3,
+                        }]
+                    },
+                    options: {
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        interaction: {
+                            intersect: false,
+                            mode: 'index',
+                        },
+                        scales: {
+                            y: {
+                                beginAtZero: false,
+                                grid: {
+                                    color: darkTheme.gridColor,
+                                },
+                                ticks: {
+                                    callback: function(value) {
+                                        return formatSats(value);
+                                    }
+                                }
+                            },
+                            x: {
+                                grid: {
+                                    color: darkTheme.gridColor,
+                                }
+                            }
+                        },
+                        plugins: {
+                            tooltip: {
+                                backgroundColor: darkTheme.borderColor,
+                                titleColor: darkTheme.textColor,
+                                bodyColor: darkTheme.textColor,
+                                borderColor: darkTheme.gridColor,
+                                borderWidth: 1,
+                                callbacks: {
+                                    label: function(context) {
+                                        return `${context.dataset.label}: ${formatSats(context.parsed.y)}`;
+                                    }
+                                }
+                            },
+                            legend: {
+                                labels: {
+                                    color: darkTheme.textColor,
+                                }
+                            }
+                        },
+                        animation: {
+                            duration: 1000,
+                            easing: 'easeInOutQuart',
+                        }
+                    }
+                });
+
+                hideChartLoading('strikeChart');
+            } catch (error) {
+                console.error('Failed to load Strike chart:', error);
+                hideChartLoading('strikeChart');
+            }
+        }
+
         async function loadPortfolioData() {
             showLoading();
 
@@ -1071,6 +1192,7 @@
             updateActiveButton('portfolio', currentPortfolioRange);
             updateActiveButton('fees', currentFeesRange);
             updateActiveButton('forwards', currentForwardsRange);
+            updateActiveButton('strike', currentStrikeRange);
 
             try {
                 const response = await fetch('/api/portfolio/current');
@@ -1087,13 +1209,14 @@
                 updateCurrentBalances(data);
                 updateLightningDetails(data);
                 updateOnchainDetails(data);
-                updateColdStorageDetails(data);
+                updateStrikeDetails();
 
                 // Load charts
                 await Promise.all([
                     createPortfolioChart(),
                     createFeesChart(),
-                    createForwardsChart()
+                    createForwardsChart(),
+                    createStrikeChart()
                 ]);
 
                 // Hide status and show dashboard
@@ -1143,6 +1266,19 @@
                     saveDateRangeToStorage(STORAGE_KEYS.FORWARDS_RANGE, days);
                     updateActiveButton('forwards', days);
                     createForwardsChart();
+                });
+            });
+
+            // Strike chart buttons
+            document.querySelectorAll('.strike-range.date-range-btn').forEach(btn => {
+                btn.addEventListener('click', function() {
+                    const days = this.getAttribute('data-days');
+                    const numDays = days === 'all' ? 'all' : parseInt(days);
+
+                    currentStrikeRange = numDays;
+                    saveDateRangeToStorage(STORAGE_KEYS.STRIKE_RANGE, days);
+                    updateActiveButton('strike', days);
+                    createStrikeChart();
                 });
             });
         }
@@ -1229,10 +1365,6 @@
                 case 'onchain':
                     // Redirect to existing on-chain addresses page
                     window.location.href = '/onchain-addresses.html';
-                    break;
-                case 'offline':
-                    // Redirect to existing cold storage page
-                    window.location.href = '/cold-storage.html';
                     break;
                 case 'analytics':
                     // TODO: Create dedicated analytics page

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -544,17 +544,32 @@
             document.getElementById('dashboard').style.display = 'none';
         }
 
-        function updateCurrentBalances(data) {
+        async function updateCurrentBalances(data) {
             const container = document.getElementById('current-balances');
-            const total = data.total_portfolio;
 
-            // Calculate percentages for each source (based on actual portfolio calculation)
+            // Calculate base components
             const components = calculatePortfolioComponents(data);
             const lightningTotal = components.lightning;
             const onchainTotal = components.onchain;
 
+            // Fetch Strike balance
+            let strikeTotal = 0;
+            try {
+                const strikeResponse = await fetch('/api/strike/balance/current?currency=BTC');
+                const strikeResult = await strikeResponse.json();
+                if (strikeResult.success && strikeResult.data) {
+                    strikeTotal = strikeResult.data.available;
+                }
+            } catch (error) {
+                console.error('Failed to fetch Strike balance for portfolio:', error);
+            }
+
+            // Calculate total including Strike
+            const total = lightningTotal + onchainTotal + strikeTotal;
+
             const lightningPercent = total > 0 ? ((lightningTotal / total) * 100).toFixed(1) : 0;
             const onchainPercent = total > 0 ? ((onchainTotal / total) * 100).toFixed(1) : 0;
+            const strikePercent = total > 0 ? ((strikeTotal / total) * 100).toFixed(1) : 0;
 
             container.innerHTML = `
                 <div class="balance-item">
@@ -568,6 +583,10 @@
                 <div class="balance-item">
                     <span class="balance-label">🔗 On-chain (${onchainPercent}%):</span>
                     <span class="balance-value">${formatSats(onchainTotal)}</span>
+                </div>
+                <div class="balance-item">
+                    <span class="balance-label">⚡ Strike (${strikePercent}%):</span>
+                    <span class="balance-value">${formatSats(strikeTotal)}</span>
                 </div>
                 <div class="balance-item">
                     <span class="balance-label">Last Updated:</span>
@@ -704,25 +723,56 @@
                 showChartLoading('portfolioChart');
 
                 const daysParam = currentPortfolioRange === 'all' ? '?days=all' : `?days=${currentPortfolioRange}`;
-                const response = await fetch(`/api/portfolio/history${daysParam}`);
-                if (!response.ok) {
-                    throw new Error(`HTTP error ${response.status}: ${response.statusText}`);
-                }
-                const result = await response.json();
 
-                if (!result.success || !result.data || result.data.length === 0) {
+                // Fetch both portfolio and Strike history
+                const [portfolioResponse, strikeResponse] = await Promise.all([
+                    fetch(`/api/portfolio/history${daysParam}`),
+                    fetch(`/api/strike/balance/history?currency=BTC${daysParam.replace('?', '&')}`)
+                ]);
+
+                if (!portfolioResponse.ok) {
+                    throw new Error(`HTTP error ${portfolioResponse.status}: ${portfolioResponse.statusText}`);
+                }
+
+                const portfolioResult = await portfolioResponse.json();
+
+                if (!portfolioResult.success || !portfolioResult.data || portfolioResult.data.length === 0) {
                     hideChartLoading('portfolioChart');
-                    console.error('No portfolio history data available:', result.error || 'Empty dataset');
+                    console.error('No portfolio history data available:', portfolioResult.error || 'Empty dataset');
                     return;
+                }
+
+                // Get Strike data (may not be available)
+                let strikeData = [];
+                let strikeBalanceByDate = {};
+                if (strikeResponse.ok) {
+                    const strikeResult = await strikeResponse.json();
+                    if (strikeResult.success && strikeResult.data && strikeResult.data.labels) {
+                        // Create a map of date -> strike balance
+                        strikeResult.data.labels.forEach((label, idx) => {
+                            const strikeDate = label.split(' ')[0]; // Get just the date part
+                            strikeBalanceByDate[strikeDate] = strikeResult.data.datasets[0].data[idx] || 0;
+                        });
+                    }
                 }
 
                 const ctx = document.getElementById('portfolioChart').getContext('2d');
 
                 // Prepare data
-                const labels = result.data.map(item => new Date(item.timestamp).toLocaleDateString());
-                const portfolioData = result.data.map(item => item.total_portfolio);
-                const lightningData = result.data.map(item => calculatePortfolioComponents(item).lightning);
-                const onchainData = result.data.map(item => calculatePortfolioComponents(item).onchain);
+                const labels = portfolioResult.data.map(item => new Date(item.timestamp).toLocaleDateString());
+                const lightningData = portfolioResult.data.map(item => calculatePortfolioComponents(item).lightning);
+                const onchainData = portfolioResult.data.map(item => calculatePortfolioComponents(item).onchain);
+
+                // Match Strike data to portfolio dates
+                strikeData = labels.map(label => {
+                    return strikeBalanceByDate[label] || 0;
+                });
+
+                // Calculate total portfolio including Strike
+                const portfolioData = portfolioResult.data.map((item, idx) => {
+                    const baseTotal = calculatePortfolioComponents(item).lightning + calculatePortfolioComponents(item).onchain;
+                    return baseTotal + (strikeData[idx] || 0);
+                });
 
                 // Destroy existing chart
                 if (portfolioChart) {
@@ -754,6 +804,14 @@
                             data: onchainData,
                             borderColor: '#FF6B35',
                             backgroundColor: '#FF6B3520',
+                            borderWidth: 2,
+                            fill: false,
+                            tension: 0.3,
+                        }, {
+                            label: '⚡ Strike',
+                            data: strikeData,
+                            borderColor: '#FF9F40',
+                            backgroundColor: '#FF9F4020',
                             borderWidth: 2,
                             fill: false,
                             tension: 0.3,


### PR DESCRIPTION
This pull request introduces a new feature for tracking Strike account balances over time. It adds a dedicated collector service, database schema, API endpoints, and documentation to support periodic retrieval and storage of Strike balances, making them accessible via the portfolio API for visualization and analysis.

**Strike Balance Tracking Feature**

*Service & Build Integration*
- Added a new `strike-balance-collector` service, including build instructions in the `Makefile`, a systemd service example for deployment, and `.env.example` configuration for the Strike API key. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L1-R7) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R34-R39) [[3]](diffhunk://#diff-f7cd39bb8535830c679c00269a97a8f05b5dcef6eb94f1d92c1242eea7afb7daR1-R35) [[4]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR12-R16)

*Database Schema & Types*
- Introduced new tables (`strike_balance_snapshots` and mock variant) and indices for storing Strike balance snapshots, along with a new `StrikeBalanceSnapshot` struct in `internal/db/types.go`. [[1]](diffhunk://#diff-7e4ba9264afd9eae1dce0c185a9141edf9c02bb44b0b76d19877389b71624006R246-R273) [[2]](diffhunk://#diff-392c9908eb9364345ab8bc58c3f048562a2bf86870efc243f91fbeafdb6307d6R99-R109)

*Strike API Client Implementation*
- Added a Strike API client (`internal/strike/client.go`) to fetch and parse account balances, converting amounts to smallest units for consistent storage.

*API Endpoints for Data Access*
- Implemented two new API endpoints in the portfolio API: `/api/strike/balance/current` for the latest balance and `/api/strike/balance/history` for historical data, both supporting currency selection and Chart.js-compatible output. [[1]](diffhunk://#diff-8dbee2aa2b1b20d4e5bcc4a4d5ee731be342e2ceb9678085f7e27afce1a44c73R165-R168) [[2]](diffhunk://#diff-8dbee2aa2b1b20d4e5bcc4a4d5ee731be342e2ceb9678085f7e27afce1a44c73R1072-R1178)

*Documentation*
- Provided a comprehensive README for the new service, detailing setup, usage, API, schema, and troubleshooting steps.